### PR TITLE
Sort by language in options list

### DIFF
--- a/options.js
+++ b/options.js
@@ -4,7 +4,7 @@ function populateVoiceList() {
     return;
   }
 
-  var voices = speechSynthesis.getVoices();
+  var voices = speechSynthesis.getVoices().sort((a, b) => a.lang.localeCompare(b.lang));
 
   for (var i = 0; i < voices.length; i++) {
     var option = document.createElement("option");
@@ -72,14 +72,14 @@ function addToBlacklist(e) {
         }
         document.querySelector("#blacklist").innerHTML = 'blacklist';
 
-   } 
+   }
 
     blacklist = JSON.stringify(blacklist);
       e.preventDefault();
       browser.storage.sync.set({
         blacklist: blacklist,
       });
-    
+
   browser.runtime.reload();
   window.close();
   }


### PR DESCRIPTION
Hello.

I had the problem that my Firefox have a lot (seriously, A lot) of voice options available.
![imagen](https://github.com/tryhardfifi/pronounce/assets/421398/276caa17-0ea6-4713-8de3-029fac27f7c6)


In this case, it was a pain to find the language I wanted to set for the plugin, so I am doing this PR to make it less difficult, with the hope this will be merged and published someday :)


peace.